### PR TITLE
Fix code scanning alert no. 1: Incomplete URL scheme check

### DIFF
--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -42,6 +42,8 @@ export const getPermalink = (slug = '', type = 'page'): string => {
     || slug.startsWith('://')
     || slug.startsWith('#')
     || slug.startsWith('javascript:')
+    || slug.startsWith('data:')
+    || slug.startsWith('vbscript:')
   ) {
     return slug;
   }


### PR DESCRIPTION
Fixes [https://github.com/isa-group/bpm2025/security/code-scanning/1](https://github.com/isa-group/bpm2025/security/code-scanning/1)

To fix the problem, we need to extend the URL scheme check to include `data:` and `vbscript:` schemes. This involves modifying the conditional check in the `getPermalink` function to also check for these schemes. The best way to fix this without changing existing functionality is to update the `if` statement on line 39 to include checks for `data:` and `vbscript:` schemes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
