### PR TITLE
refactor: reduce bundle size

### DIFF
--- a/src/components/ui/ImageGrid.astro
+++ b/src/components/ui/ImageGrid.astro
@@ -22,9 +22,7 @@ const {
       {/* @ts-expect-error - Track https://github.com/withastro/astro/issues/10780 */}
       <Image
         class="mx-auto w-full rounded-lg bg-gray-500 shadow-lg "
-        width={500}
         height={500}
-        widths={[400, 768]}
         sizes="(max-width: 768px) 100vw, 432px"
         {...i}
         description={undefined}

--- a/src/components/widgets/Content.astro
+++ b/src/components/widgets/Content.astro
@@ -81,9 +81,7 @@ const {
                 {/* @ts-expect-error - Track https://github.com/withastro/astro/issues/10780 */}
                 <Image
                   class={`mx-auto w-full rounded-lg shadow-lg ${classes?.images ?? ''}`}
-                  width={500}
                   height={500}
-                  widths={[400, 768]}
                   sizes="(max-width: 768px) 100vw, 432px"
                   {...i}
                   description={undefined}

--- a/src/components/widgets/Hero.astro
+++ b/src/components/widgets/Hero.astro
@@ -82,10 +82,8 @@ const {
               {/* @ts-expect-error - Track https://github.com/withastro/astro/issues/10780 */}
               <Image
                 class="mx-auto rounded-md w-full"
-                widths={[400, 768, 1024, 2040]}
                 sizes="(max-width: 767px) 400px, (max-width: 1023px) 768px, (max-width: 2039px) 1024px, 2040px"
                 loading="eager"
-                width={1024}
                 height={576}
                 {...image}
               />

--- a/src/components/widgets/Steps.astro
+++ b/src/components/widgets/Steps.astro
@@ -42,9 +42,7 @@ const {
           {/* @ts-expect-error - Track https://github.com/withastro/astro/issues/10780 */}
           <Image
             class="inset-0 object-cover object-top w-full rounded-md shadow-lg md:absolute md:h-full bg-gray-400 dark:bg-slate-700"
-            widths={[400, 768]}
             sizes="(max-width: 768px) 100vw, 432px"
-            width={432}
             height={768}
             {...image}
           />


### PR DESCRIPTION
Don't generate images in multiple sizes, reducing the final total size of the page. The .webp format is already efficient enough without the need of duplicating assets