### PR TITLE
fix: mark dark class selector as global

### DIFF
--- a/packages/frontend/src/components/widgets/Header.astro
+++ b/packages/frontend/src/components/widgets/Header.astro
@@ -165,7 +165,7 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
     box-shadow: 0 0.375rem 1.5rem 0 rgb(140 152 164 / 13%);
   }
 
-  .dark header.scroll > div:first-child,
+  :global(.dark) header.scroll > div:first-child,
   header.scroll.dark > div:first-child {
     --at-apply: bg-page md:bg-[#030621e6] border-b border-gray-500/20;
     box-shadow: none;

--- a/packages/frontend/src/pages/program/keynotes.astro
+++ b/packages/frontend/src/pages/program/keynotes.astro
@@ -77,7 +77,7 @@ import { keynotes } from '#/data/keynotes';
 </Layout>
 
 <style>
-.dark .speaker-gradient {
+:global(.dark) .speaker-gradient {
   --bg-color: var(--aw-color-bg-page-dark);
 }
 


### PR DESCRIPTION
Fixes #216 

dark is a global class, but Astro's is not aware of that while doing style scoping, so it was attached to the current element

With :global(.dark) we can tell Astro that this specific selector must not be scoped